### PR TITLE
Fix memory leak

### DIFF
--- a/VTFLib/VTFFile.cpp
+++ b/VTFLib/VTFFile.cpp
@@ -955,6 +955,17 @@ vlBool CVTFFile::Create(vlUInt uiWidth, vlUInt uiHeight, vlUInt uiFrames, vlUInt
 		this->SetStartFrame(VTFCreateOptions.uiStartFrame);
 		this->SetBumpmapScale(VTFCreateOptions.sBumpScale);
 
+		if(lpNewImageDataRGBA8888 != 0)
+		{
+			for(vlUInt i = 0; i < uiCount; i++)
+			{
+				delete []lpNewImageDataRGBA8888[i];
+			}
+			delete []lpNewImageDataRGBA8888;
+		}
+
+		this->Destroy();
+
 		return vlTrue;
 	}
 	catch(...)


### PR DESCRIPTION
If the result is successful, then the allocated memory is not cleared. This adds deallocate memory if the result is successful.